### PR TITLE
Add Carousel component for embedded video

### DIFF
--- a/.env
+++ b/.env
@@ -18,3 +18,5 @@ MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 # If the app is being served in from a subfolder, the domain url must be set.
 # For example, if the app is served from /mysite:
 # PUBLIC_URL=http://example.com/mysite
+
+GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f88hX8RZ4Qef7qBsTtDqxjTSkg/viewform?embedded=true'

--- a/.env
+++ b/.env
@@ -18,5 +18,3 @@ MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 # If the app is being served in from a subfolder, the domain url must be set.
 # For example, if the app is served from /mysite:
 # PUBLIC_URL=http://example.com/mysite
-
-GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f88hX8RZ4Qef7qBsTtDqxjTSkg/viewform?embedded=true'

--- a/custom-pages/visit/component.tsx
+++ b/custom-pages/visit/component.tsx
@@ -28,7 +28,8 @@ export default function VisitPage() {
         <FoldSection>
           <StyledH2> Features </StyledH2>
           <RelatedContents storyIds={visitLocationFeaturesStoryIds} />
-        </FoldSection><FoldSection>
+        </FoldSection>
+        <FoldSection>
           <StyledH2> Locations </StyledH2>
           <RelatedContents storyIds={visitLocationStoryIds} />
         </FoldSection>

--- a/overrides/common/carousel.js
+++ b/overrides/common/carousel.js
@@ -1,0 +1,160 @@
+import React from "$veda-ui/react";
+import styled from "$veda-ui/styled-components";
+import {
+  CarouselProvider,
+  Slider,
+  Slide,
+  ButtonBack,
+  ButtonNext,
+  DotGroup,
+} from "pure-react-carousel";
+import Embed from "$veda-ui-scripts/components/common/blocks/embed";
+// required CSS for pure-react-carousel
+import "pure-react-carousel/dist/react-carousel.es.css";
+import { useMediaQuery } from "$veda-ui-scripts/utils/use-media-query";
+
+import {
+  CollecticonChevronLeft,
+  CollecticonChevronRight,
+} from "$veda-ui/@devseed-ui/collecticons";
+
+import { createButtonStyles } from "$veda-ui/@devseed-ui/button";
+import { focusStyle } from "./style";
+
+import {
+  glsp,
+  listReset,
+  media,
+  themeVal,
+  visuallyHidden,
+} from "$veda-ui/@devseed-ui/theme-provider";
+
+const SROnly = styled.span`
+  font-size: 0;
+`;
+const FeaturedList = styled.div`
+  /* ignore stylelint parseError */
+  ${listReset()}
+  .carousel__slider {
+    border-radius: ${themeVal("shape.rounded")};
+  }
+`;
+
+const FeaturedContent = styled.div`
+  width: 100%;
+  article {
+    min-height: 16rem;
+    ${media.smallUp`
+      min-height: 20rem;
+    `}
+    ${media.mediumUp`
+      min-height: 20rem;
+    `}
+    ${media.largeUp`
+      min-height: 24rem;
+    `}
+    ${media.xlargeUp`
+      min-height: 28rem;
+    `}
+  }
+  /* overriding pure-react-carousel styles */
+  > div {
+    width: 100% !important;
+  }
+`;
+
+const ButtonGroup = styled.div`
+  position: absolute;
+  display: flex;
+  gap: ${glsp(1)};
+  top: calc(${(props) => props.topHeight}px + ${glsp(4)});
+  left: unset;
+`;
+
+const buttonStyle = createButtonStyles({
+  variation: "achromic-text",
+  fitting: "skinny",
+});
+
+const ButtonBackStyled = styled(ButtonBack)`
+  ${buttonStyle}
+  background-color: ${themeVal("color.primary")};
+  &:hover {
+    background-color: ${themeVal("color.secondary")};
+  }
+  &:active,
+  &:focus,
+  &:hover {
+    ${focusStyle}
+  }
+`;
+
+const ButtonNextStyled = styled(ButtonNext)`
+  ${buttonStyle}
+  background-color: ${themeVal("color.primary")};
+  &:hover {
+    background-color: ${themeVal("color.secondary")};
+  }
+  &:active,
+  &:focus,
+  &:hover {
+    ${focusStyle}
+  }
+`;
+
+const DescWrapper = styled.div`
+  margin: ${glsp(3)} 0;
+`;
+
+export default function Carousel({ items }) {
+  const { isLargeUp } = useMediaQuery();
+  const height = isLargeUp ? 515 : 315;
+  console.log;
+  return (
+    <CarouselProvider
+      isIntrinsicHeight={true}
+      totalSlides={items.length}
+      style={{ gridColumn: "1 / -1", gridRow: "2", position: "relative" }}
+    >
+      <div role="region" aria-label="Carousel">
+        <FeaturedList>
+          <Slider>
+            {items.map((t, idx) => (
+              <FeaturedContent
+                key={t.desc}
+                role="group"
+                aria-roledescription="Slide"
+                aria-labelledby={`carousel-item-${idx}__label`}
+              >
+                <Slide index={idx}>
+                  <Embed
+                    height={height}
+                    src={t.src}
+                    title="YouTube video player"
+                  ></Embed>
+                  <DescWrapper>{t.caption}</DescWrapper>
+                </Slide>
+                <SROnly id={`carousel-item-${idx}__label`}>{t.title}</SROnly>
+              </FeaturedContent>
+            ))}
+          </Slider>
+        </FeaturedList>
+
+        {items.length > 1 && (
+          <ButtonGroup
+            topHeight={height}
+            role="group"
+            aria-label="Slide controls"
+          >
+            <ButtonBackStyled>
+              <CollecticonChevronLeft title="Go to previous slide" meaningful />
+            </ButtonBackStyled>
+            <ButtonNextStyled>
+              <CollecticonChevronRight title="Go to next slide" meaningful />
+            </ButtonNextStyled>
+          </ButtonGroup>
+        )}
+      </div>
+    </CarouselProvider>
+  );
+}

--- a/overrides/common/embedded-video-carousel.tsx
+++ b/overrides/common/embedded-video-carousel.tsx
@@ -8,13 +8,12 @@ import {
   ButtonNext,
   DotGroup,
 } from "pure-react-carousel";
+import Lazyload from "$veda-ui/react-lazyload";
 import {
   CollecticonChevronLeft,
   CollecticonChevronRight,
 } from "$veda-ui/@devseed-ui/collecticons";
-
 import { createButtonStyles } from "$veda-ui/@devseed-ui/button";
-
 import {
   glsp,
   listReset,
@@ -25,6 +24,7 @@ import {
 
 import Embed from "$veda-ui-scripts/components/common/blocks/embed";
 import { useMediaQuery } from "$veda-ui-scripts/utils/use-media-query";
+import { LoadingSkeleton } from "$veda-ui-scripts/components/common/loading-skeleton";
 // required CSS for pure-react-carousel
 import "pure-react-carousel/dist/react-carousel.es.css";
 
@@ -117,49 +117,58 @@ export default function Carousel({ items }: EmbeddedVideosPropType) {
   const { isLargeUp } = useMediaQuery();
   const height = isLargeUp ? 515 : 315;
   return (
-    <CarouselProvider
-      isIntrinsicHeight={true}
-      totalSlides={items.length}
-      style={{ gridColumn: "1 / -1", gridRow: "2", position: "relative" }}
+    <Lazyload
+      placeholder={<LoadingSkeleton height={height} />}
+      offset={100}
+      once
     >
-      <div role="region" aria-label="Carousel">
-        <FeaturedList>
-          <Slider>
-            {items.map((t, idx) => (
-              <FeaturedContent
-                key={t.title}
-                role="group"
-                aria-roledescription="Slide"
-                aria-labelledby={`carousel-item-${idx}__label`}
-              >
-                <Slide index={idx}>
-                  <Embed height={height} src={t.src}></Embed>
-                  <DescWrapper>
-                    <h3>{t.title}</h3>
-                    <p>{t.caption}</p>
-                  </DescWrapper>
-                </Slide>
-                <SROnly id={`carousel-item-${idx}__label`}>{t.title}</SROnly>
-              </FeaturedContent>
-            ))}
-          </Slider>
-        </FeaturedList>
+      <CarouselProvider
+        isIntrinsicHeight={true}
+        totalSlides={items.length}
+        style={{ gridColumn: "1 / -1", gridRow: "2", position: "relative" }}
+      >
+        <div role="region" aria-label="Carousel">
+          <FeaturedList>
+            <Slider>
+              {items.map((t, idx) => (
+                <FeaturedContent
+                  key={t.title}
+                  role="group"
+                  aria-roledescription="Slide"
+                  aria-labelledby={`carousel-item-${idx}__label`}
+                >
+                  <Slide index={idx}>
+                    <Embed height={height} src={t.src}></Embed>
+                    <DescWrapper>
+                      <h3>{t.title}</h3>
+                      <p>{t.caption}</p>
+                    </DescWrapper>
+                  </Slide>
+                  <SROnly id={`carousel-item-${idx}__label`}>{t.title}</SROnly>
+                </FeaturedContent>
+              ))}
+            </Slider>
+          </FeaturedList>
 
-        {items.length > 1 && (
-          <ButtonGroup
-            topHeight={height}
-            role="group"
-            aria-label="Slide controls"
-          >
-            <ButtonBackStyled>
-              <CollecticonChevronLeft title="Go to previous slide" meaningful />
-            </ButtonBackStyled>
-            <ButtonNextStyled>
-              <CollecticonChevronRight title="Go to next slide" meaningful />
-            </ButtonNextStyled>
-          </ButtonGroup>
-        )}
-      </div>
-    </CarouselProvider>
+          {items.length > 1 && (
+            <ButtonGroup
+              topHeight={height}
+              role="group"
+              aria-label="Slide controls"
+            >
+              <ButtonBackStyled>
+                <CollecticonChevronLeft
+                  title="Go to previous slide"
+                  meaningful
+                />
+              </ButtonBackStyled>
+              <ButtonNextStyled>
+                <CollecticonChevronRight title="Go to next slide" meaningful />
+              </ButtonNextStyled>
+            </ButtonGroup>
+          )}
+        </div>
+      </CarouselProvider>
+    </Lazyload>
   );
 }

--- a/overrides/common/embedded-video-carousel.tsx
+++ b/overrides/common/embedded-video-carousel.tsx
@@ -144,7 +144,7 @@ export default function Carousel({ items }: EmbeddedVideosPropType) {
                       title={t.title}
                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                       allowfullscreen
-                    ></Embed>
+                    />
                     <DescWrapper>
                       <h3>{t.title}</h3>
                       <p>{t.caption}</p>

--- a/overrides/common/embedded-video-carousel.tsx
+++ b/overrides/common/embedded-video-carousel.tsx
@@ -138,7 +138,13 @@ export default function Carousel({ items }: EmbeddedVideosPropType) {
                   aria-labelledby={`carousel-item-${idx}__label`}
                 >
                   <Slide index={idx}>
-                    <Embed height={height} src={t.src}></Embed>
+                    <Embed
+                      height={height}
+                      src={t.src}
+                      title={t.title}
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                      allowfullscreen
+                    ></Embed>
                     <DescWrapper>
                       <h3>{t.title}</h3>
                       <p>{t.caption}</p>

--- a/overrides/common/embedded-video-carousel.tsx
+++ b/overrides/common/embedded-video-carousel.tsx
@@ -115,7 +115,7 @@ interface EmbeddedVideosPropType {
 
 export default function Carousel({ items }: EmbeddedVideosPropType) {
   const { isLargeUp } = useMediaQuery();
-  const height = isLargeUp ? 515 : 315;
+  const height = isLargeUp ? 500 : 315;
   return (
     <Lazyload
       placeholder={<LoadingSkeleton height={height} />}

--- a/overrides/common/embedded-video-carousel.tsx
+++ b/overrides/common/embedded-video-carousel.tsx
@@ -8,18 +8,12 @@ import {
   ButtonNext,
   DotGroup,
 } from "pure-react-carousel";
-import Embed from "$veda-ui-scripts/components/common/blocks/embed";
-// required CSS for pure-react-carousel
-import "pure-react-carousel/dist/react-carousel.es.css";
-import { useMediaQuery } from "$veda-ui-scripts/utils/use-media-query";
-
 import {
   CollecticonChevronLeft,
   CollecticonChevronRight,
 } from "$veda-ui/@devseed-ui/collecticons";
 
 import { createButtonStyles } from "$veda-ui/@devseed-ui/button";
-import { focusStyle } from "./style";
 
 import {
   glsp,
@@ -29,8 +23,15 @@ import {
   visuallyHidden,
 } from "$veda-ui/@devseed-ui/theme-provider";
 
+import Embed from "$veda-ui-scripts/components/common/blocks/embed";
+import { useMediaQuery } from "$veda-ui-scripts/utils/use-media-query";
+// required CSS for pure-react-carousel
+import "pure-react-carousel/dist/react-carousel.es.css";
+
+import { focusStyle } from "./style";
+
 const SROnly = styled.span`
-  font-size: 0;
+  ${visuallyHidden}
 `;
 const FeaturedList = styled.div`
   /* ignore stylelint parseError */
@@ -106,10 +107,15 @@ const DescWrapper = styled.div`
   margin: ${glsp(3)} 0;
 `;
 
-export default function Carousel({ items }) {
+interface EmbeddedVideosPropType {
+  src: string;
+  title: string;
+  caption: string;
+}
+
+export default function Carousel({ items }: EmbeddedVideosPropType) {
   const { isLargeUp } = useMediaQuery();
   const height = isLargeUp ? 515 : 315;
-  console.log;
   return (
     <CarouselProvider
       isIntrinsicHeight={true}
@@ -121,18 +127,17 @@ export default function Carousel({ items }) {
           <Slider>
             {items.map((t, idx) => (
               <FeaturedContent
-                key={t.desc}
+                key={t.title}
                 role="group"
                 aria-roledescription="Slide"
                 aria-labelledby={`carousel-item-${idx}__label`}
               >
                 <Slide index={idx}>
-                  <Embed
-                    height={height}
-                    src={t.src}
-                    title="YouTube video player"
-                  ></Embed>
-                  <DescWrapper>{t.caption}</DescWrapper>
+                  <Embed height={height} src={t.src}></Embed>
+                  <DescWrapper>
+                    <h3>{t.title}</h3>
+                    <p>{t.caption}</p>
+                  </DescWrapper>
                 </Slide>
                 <SROnly id={`carousel-item-${idx}__label`}>{t.title}</SROnly>
               </FeaturedContent>

--- a/package.json
+++ b/package.json
@@ -32,5 +32,7 @@
     "$veda-ui": "./.veda/ui/node_modules",
     "$veda-ui-scripts": "./.veda/ui/app/scripts"
   },
-  "dependencies": {}
+  "dependencies": {
+    "pure-react-carousel": "^1.30.1"
+  }
 }

--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -25,12 +25,12 @@ taxonomy:
     values:
       - Hyperwall
 ---
-import Carousel from lazy(() => import("../overrides/common/embedded-video-carousel"));
+import Carousel from "../overrides/common/embedded-video-carousel";
 import contentArray from './locfeature.HYPER/carousel_content.json';
 
 
 <Block type='wide'>
   <Figure>
     <Carousel items={contentArray} />
-    </Figure>
+  </Figure>
 </Block>

--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -25,12 +25,12 @@ taxonomy:
     values:
       - Hyperwall
 ---
-import Carousel from "../overrides/common/embedded-video-carousel";
+import Carousel from lazy(() => import("../overrides/common/embedded-video-carousel"));
 import contentArray from './locfeature.HYPER/carousel_content.json';
 
 
-    <Block type='wide'>
-          <Figure>
-              <Carousel items={contentArray} />
-              </Figure>
-          </Block>
+<Block type='wide'>
+  <Figure>
+    <Carousel items={contentArray} />
+    </Figure>
+</Block>

--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -25,12 +25,12 @@ taxonomy:
     values:
       - Hyperwall
 ---
-import Carousel from "../overrides/common/carousel";
+import Carousel from "../overrides/common/embedded-video-carousel";
 import contentArray from './locfeature.HYPER/carousel_content.json';
 
 
-<Block type='wide'>
-    <Figure>
-        <Carousel items={contentArray} />
-  </Figure>
-</Block>
+    <Block type='wide'>
+          <Figure>
+              <Carousel items={contentArray} />
+              </Figure>
+          </Block>

--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -25,8 +25,12 @@ taxonomy:
     values:
       - Hyperwall
 ---
-
-import Carousel from './components/carousel.jsx';
+import Carousel from "../overrides/common/carousel";
 import contentArray from './locfeature.HYPER/carousel_content.json';
 
-<Carousel {...{contentArray}} />
+
+<Block type='wide'>
+    <Figure>
+        <Carousel items={contentArray} />
+  </Figure>
+</Block>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.5.5":
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
+  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@colors/colors@1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
@@ -495,6 +502,16 @@ debug@^4.1.1, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+deep-freeze@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+  integrity sha512-Z+z8HiAvsGwmjqlphnHW5oz6yWlOwu6EQfFTjmeTWlDeda3FS2yv3jhq35TX/ewmsnqB+RX2IdsIOyjJCQN5tg==
+
+deepmerge@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
@@ -529,6 +546,13 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
+
+equals@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/equals/-/equals-1.0.5.tgz#212062dde5e1a510d955f13598efcc6a621b6ace"
+  integrity sha512-wI15a6ZoaaXPv+55+Vh2Kqn3+efKRv8QPtcGTjW5xmanMnQzESdAt566jevtMZyt3W/jwLDTzXpMph5ECDJ2zg==
+  dependencies:
+    jkroso-type "1"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -703,6 +727,16 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
+jkroso-type@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/jkroso-type/-/jkroso-type-1.1.1.tgz#bc4ced6d6c45fe0745282bafc86a9f8c4fc9ce61"
+  integrity sha512-zZgay+fPG6PgMUrpyFADmQmvLo39+AZa7Gc5pZhev2RhDxwANEq2etwD8d0e6rTg5NkwOIlQmaEmns3draC6Ng==
+
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 json5@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -741,6 +775,13 @@ logform@^2.3.2, logform@^2.4.0:
     ms "^2.1.1"
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -879,7 +920,7 @@ nullthrows@^1.1.1:
   resolved "https://registry.yarnpkg.com/nullthrows/-/nullthrows-1.1.1.tgz#7818258843856ae971eae4208ad7d7eb19a431b1"
   integrity sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==
 
-object-assign@^4:
+object-assign@^4, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
@@ -935,6 +976,15 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+prop-types@^15.6.2:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -942,6 +992,17 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+pure-react-carousel@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/pure-react-carousel/-/pure-react-carousel-1.30.1.tgz#006a333869b51339dafcdee2afa0561eb46d1743"
+  integrity sha512-B1qi62hZk0OFqRR4cTjtgIeOn/Ls5wo+HsLtrXT4jVf5et8ldBHSt+6LsYRJN86Or8dm+XbnJNEHy6WDJ0/DQw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    deep-freeze "0.0.1"
+    deepmerge "^2.2.1"
+    equals "^1.0.5"
+    prop-types "^15.6.2"
 
 qs@6.11.0:
   version "6.11.0"
@@ -965,6 +1026,11 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-is@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
@@ -973,6 +1039,11 @@ readable-stream@^3.4.0, readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 safe-buffer@5.1.2:
   version "5.1.2"


### PR DESCRIPTION
- It is good to keep in mind that users rarely interact with carousels. When vertical space is allowed, it is considered better not to use it: https://www.smashingmagazine.com/2022/04/designing-better-carousel-ux/#do-users-actually-use-carousels 
- The carousel in this pr is not meant for any element, it is specifically for embedded video.

Close #15 
example video carousel:  https://deploy-preview-23--earth-information-center.netlify.app/stories/hyperwall
