### PR TITLE
Add current slide number/total slide number to carousel 

### DIFF
--- a/overrides/common/embedded-video-carousel.tsx
+++ b/overrides/common/embedded-video-carousel.tsx
@@ -70,6 +70,7 @@ const ButtonGroup = styled.div`
   gap: ${glsp(1)};
   top: calc(${(props) => props.topHeight}px + ${glsp(4)});
   left: unset;
+  align-items: center;
 `;
 
 const buttonStyle = createButtonStyles({
@@ -155,7 +156,6 @@ export default function Carousel({ items }: EmbeddedVideosPropType) {
               ))}
             </Slider>
           </FeaturedList>
-
           {items.length > 1 && (
             <ButtonGroup
               topHeight={height}
@@ -168,6 +168,16 @@ export default function Carousel({ items }: EmbeddedVideosPropType) {
                   meaningful
                 />
               </ButtonBackStyled>
+              {/* A workaround to show current slide number/ total slide number */}
+              <DotGroup
+                renderDots={(props) => {
+                  return (
+                    <span>
+                      {props.currentSlide + 1}/{items.length + 1}
+                    </span>
+                  );
+                }}
+              />
               <ButtonNextStyled>
                 <CollecticonChevronRight title="Go to next slide" meaningful />
               </ButtonNextStyled>

--- a/overrides/common/embedded-video-carousel.tsx
+++ b/overrides/common/embedded-video-carousel.tsx
@@ -71,6 +71,7 @@ const ButtonGroup = styled.div`
   top: calc(${(props) => props.topHeight}px + ${glsp(4)});
   left: unset;
   align-items: center;
+  z-index: 5;
 `;
 
 const buttonStyle = createButtonStyles({
@@ -128,6 +129,30 @@ export default function Carousel({ items }: EmbeddedVideosPropType) {
         totalSlides={items.length}
         style={{ gridColumn: "1 / -1", gridRow: "2", position: "relative" }}
       >
+        {items.length > 1 && (
+          <ButtonGroup
+            topHeight={height}
+            role="group"
+            aria-label="Slide controls"
+          >
+            <ButtonBackStyled>
+              <CollecticonChevronLeft title="Go to previous slide" meaningful />
+            </ButtonBackStyled>
+            {/* A workaround to show current slide number/ total slide number */}
+            <DotGroup
+              renderDots={(props) => {
+                return (
+                  <span>
+                    {props.currentSlide + 1}/{items.length + 1}
+                  </span>
+                );
+              }}
+            />
+            <ButtonNextStyled>
+              <CollecticonChevronRight title="Go to next slide" meaningful />
+            </ButtonNextStyled>
+          </ButtonGroup>
+        )}
         <div role="region" aria-label="Carousel">
           <FeaturedList>
             <Slider>
@@ -151,38 +176,13 @@ export default function Carousel({ items }: EmbeddedVideosPropType) {
                       <p>{t.caption}</p>
                     </DescWrapper>
                   </Slide>
-                  <SROnly id={`carousel-item-${idx}__label`}>{t.title}</SROnly>
+                  <SROnly id={`carousel-item-${idx}__label`} aria-live="polite">
+                    {t.title}
+                  </SROnly>
                 </FeaturedContent>
               ))}
             </Slider>
           </FeaturedList>
-          {items.length > 1 && (
-            <ButtonGroup
-              topHeight={height}
-              role="group"
-              aria-label="Slide controls"
-            >
-              <ButtonBackStyled>
-                <CollecticonChevronLeft
-                  title="Go to previous slide"
-                  meaningful
-                />
-              </ButtonBackStyled>
-              {/* A workaround to show current slide number/ total slide number */}
-              <DotGroup
-                renderDots={(props) => {
-                  return (
-                    <span>
-                      {props.currentSlide + 1}/{items.length + 1}
-                    </span>
-                  );
-                }}
-              />
-              <ButtonNextStyled>
-                <CollecticonChevronRight title="Go to next slide" meaningful />
-              </ButtonNextStyled>
-            </ButtonGroup>
-          )}
         </div>
       </CarouselProvider>
     </Lazyload>


### PR DESCRIPTION
Display current slide number for Carousel. 

Check one item in : https://github.com/NASA-IMPACT/veda-config-eic/issues/30

This is probably not an ideal way to do this (because `DotGroup` component is not really designed for this job, but it just happens to have the props that carousel needs - `currentSlide`), but it is surely a fast way. 

You can see how it looks : https://deploy-preview-33--earth-information-center.netlify.app/stories/hyperwall  

@agurvich ☝️ I hope this helps Carousel experience.

Also, I'd like to note that the keyboard navigation is very difficult with the current Carousel. This raises the accessibility issue.  I did a little bit of tweak hoping that helps keyboard navigation, but not sure if that is enough. Related to the accessibility issue, the slide title in the carousel is encoded as `h3`. It will make sense if we can give h2 title to carousel itself. 