### PR TITLE
Add google form link only to footer

### DIFF
--- a/overrides/components/page-footer/component.tsx
+++ b/overrides/components/page-footer/component.tsx
@@ -51,12 +51,6 @@ const FooterMenu = styled.ul`
     align-items: center;
     gap: ${glsp(3)};
   `}
-
-  li:last-child {
-    ${media.mediumUp`
-      margin-left: auto;
-    `}
-  }
 `;
 
 const FooterMenuLink = styled(NavLink)`
@@ -278,33 +272,12 @@ export default function PageFooter(props) {
                 <FooterMenuLink to={ABOUT_PATH}>About</FooterMenuLink>
               </li>
               <li>
-                {process.env.GOOGLE_FORM ? (
-                  isMediumUp ? (
-                    <Button
-                      variation="primary-outline"
-                      size="large"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        show();
-                      }}
-                    >
-                      Contact Us
-                    </Button>
-                  ) : (
-                    <FooterMenuLink
-                      as="a"
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        show();
-                      }}
-                    >
-                      Contact Us
-                    </FooterMenuLink>
-                  )
-                ) : (
-                  false
-                )}
+                <FooterMenuLink
+                  as="a"
+                  href="https://docs.google.com/forms/d/1mDgFqUsNv90Js7pERNDbmyN5RksztIy5ZZojWD0n5Pg"
+                >
+                  Contact Us
+                </FooterMenuLink>
               </li>
             </FooterMenu>
           </nav>


### PR DESCRIPTION
Add 'Contact us' which is a link to Google Form to the footer.
🤚  This does not open the feedback form in the modal. This transitions the page to Google form page.

