### PR TITLE
Rename topics to theme

### DIFF
--- a/datasets/cmip6-climdex-tmaxxf-access-cm2.data.mdx
+++ b/datasets/cmip6-climdex-tmaxxf-access-cm2.data.mdx
@@ -10,7 +10,7 @@ media:
     name: NASA
     url: 
 taxonomy:
-  - name: Topics
+  - name: Theme
     values:
       - Greenhouse Gases
   - name: Source


### PR DESCRIPTION
We're using "theme" instead of "topics" in EIC site-wide