### PR TITLE
Remove trailing slash from api urls

### DIFF
--- a/.env
+++ b/.env
@@ -8,10 +8,10 @@ APP_DESCRIPTION='Explore our changing planet.'
 APP_CONTACT_EMAIL=eleanor.stokes@nasa.gov
 
 # Endpoint for the Tiler server. No trailing slash.
-API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com/'
+API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
 
 # Endpoint for the STAC server. No trailing slash.
-API_STAC_ENDPOINT='https://staging-stac.delta-backend.com/'
+API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
 
 MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 


### PR DESCRIPTION
Removing trailing slashes in the API urls that was causing issue with analysis