### PR TITLE
Add default analysis metric to all datasets

### DIFF
--- a/datasets/cmip6-climdex-tmaxxf-access-cm2.data.mdx
+++ b/datasets/cmip6-climdex-tmaxxf-access-cm2.data.mdx
@@ -43,6 +43,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days
@@ -80,6 +82,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days
@@ -117,6 +121,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days
@@ -154,6 +160,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days
@@ -191,6 +199,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days
@@ -228,6 +238,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days
@@ -265,6 +277,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days
@@ -302,6 +316,8 @@ layers:
         }      
     analysis:
       exclude: false
+      metrics:
+        - mean
     legend:
       unit: 
         label: Days

--- a/datasets/co2.mdx
+++ b/datasets/co2.mdx
@@ -47,6 +47,10 @@ layers:
         - "#fee090"
         - "#fc8d59"
         - "#d73027"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-diff
     stacCol: co2-diff
     name: Difference CO2
@@ -77,6 +81,10 @@ layers:
         - "#f39779"
         - "#db5c48"
         - "#b50021"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block type='wide'>

--- a/datasets/ecco-sea-surface-height.mdx
+++ b/datasets/ecco-sea-surface-height.mdx
@@ -34,6 +34,10 @@ layers:
         - "#EF8A62"
         - "#F7F7F7"
         - "#67A9CF"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 
 ---
 

--- a/datasets/geoglam.data.mdx
+++ b/datasets/geoglam.data.mdx
@@ -52,6 +52,10 @@ layers:
           label: "Out of Season"
         - color: "#804115"
           label: "No Data"
+    analysis:
+      exclude: false
+      metrics:
+        - median
 ---
 
 <Block type='wide'>

--- a/datasets/grdi-v1.data.mdx
+++ b/datasets/grdi-v1.data.mdx
@@ -42,6 +42,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: grdi-filled-missing-values-count
     stacCol: grdi-filled-missing-values-count
     name: GRDI Constituent Inputs
@@ -65,6 +69,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+      analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: grdi-v1-built
     stacCol: grdi-v1-built
     name: GRDI Built-Up Area (BUILT)
@@ -88,6 +96,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: grdi-cdr-raster
     stacCol: grdi-cdr-raster
     name: GRDI Child Dependency Ratio (CDR)
@@ -111,6 +123,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: grdi-imr-raster
     stacCol: grdi-imr-raster
     name: GRDI Infant Mortality Rate (IMR)
@@ -134,6 +150,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: grdi-shdi-raster
     stacCol: grdi-shdi-raster
     name: GRDI Subnational Human Development Index (SHDI)
@@ -157,6 +177,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: grdi-vnl-raster
     stacCol: grdi-vnl-raster
     name: GRDI VIIRS Night Lights (VNL)
@@ -180,6 +204,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: grdi-vnl-slope-raster
     stacCol: grdi-vnl-slope-raster
     name: GRDI VIIRS Night Lights (VNL) Slope
@@ -203,6 +231,10 @@ layers:
         - '#21918c'
         - '#5ec962'
         - '#fde725'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block type='wide'>

--- a/datasets/hls-ej.mdx
+++ b/datasets/hls-ej.mdx
@@ -41,6 +41,10 @@ layers:
         ::js ({ dateFns, datetime, compareDatetime }) => {
           return `${dateFns.format(datetime, 'LLL yyyy')} VS ${dateFns.format(compareDatetime, 'LLL yyyy')}`;
         }
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: hls-s30-002-ej
     stacCol: hls-s30-002-ej-reprocessed
     name: HLS Sentinel-2 SWIR
@@ -55,6 +59,10 @@ layers:
         - B12
         - B8A
         - B04
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block>

--- a/datasets/land-cover.mdx
+++ b/datasets/land-cover.mdx
@@ -46,6 +46,10 @@ layers:
         ::js ({ dateFns, datetime, compareDatetime }) => {
           if (dateFns && datetime && compareDatetime) return `${dateFns.format(datetime, 'LLL yyyy')} VS ${dateFns.format(compareDatetime, 'LLL yyyy')}`;
         }
+    analysis:
+      exclude: false
+      metrics:
+        - median
 ---
 
 <Block>

--- a/datasets/new-urbanization.mdx
+++ b/datasets/new-urbanization.mdx
@@ -35,6 +35,10 @@ layers:
           label: No Data
         - color: "#d73027"
           label: Urbanization
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 
   
 ---

--- a/datasets/no2.data.mdx
+++ b/datasets/no2.data.mdx
@@ -54,6 +54,10 @@ layers:
         - '#E4EEF3'
         - '#FDDCC9'
         - '#DD7059'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: no2-monthly-diff
     stacCol: no2-monthly-diff
     name: Nitrogen Dioxide (NO₂) Difference
@@ -88,6 +92,10 @@ layers:
         - '#E4EEF3'
         - '#FDDCC9'
         - '#DD7059'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block type='wide'>

--- a/datasets/ocean-npp.mdx
+++ b/datasets/ocean-npp.mdx
@@ -44,6 +44,10 @@ layers:
         - "#ffff00"
         - "#fa0000"
         - "#800000"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block>

--- a/datasets/oco2-mip-co2budget.mdx
+++ b/datasets/oco2-mip-co2budget.mdx
@@ -80,6 +80,10 @@ layers:
         - '#F18D6F'
         - '#D95847'
         - '#B40426'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-lnlgis-nbe-std
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Uncertainty - LNLGIS Net Biosphere Exchange (LNLGIS_NBE_std)
@@ -123,6 +127,10 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-lnlgis-nce
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: LNLGIS Net Carbon Exchange (LNLGIS_NCE)
@@ -166,6 +174,10 @@ layers:
         - '#F18D6F'
         - '#D95847'
         - '#B40426'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-lnlgis-nce-std
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name:  Uncertainty - LNLGIS Net Carbon Exchange (LNLGIS_NCE_std)
@@ -209,6 +221,10 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-lnlgis-dc-loss
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: LNLGIS Net Land Carbon Stock Loss (LNLGIS_dC_loss)
@@ -252,6 +268,10 @@ layers:
         - '#F18D6F'
         - '#D95847'
         - '#B40426'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-lnlgis-dc-loss-std
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name:  LNLGIS Net Land Carbon Stock Loss (LNLGIS_dC_loss_std)
@@ -295,6 +315,10 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-crop
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Lateral Crop CO₂ Flux (Crop)
@@ -338,6 +362,10 @@ layers:
         - '#F18D6F'
         - '#D95847'
         - '#B40426'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-crop-std
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Uncertainty - Lateral Crop CO₂ Flux (Crop_std)
@@ -381,6 +409,10 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-ff
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name:  Fossil Fuel and Cement CO₂ Emissions (FF)
@@ -424,6 +456,10 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-ff-std
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Uncertainty - Fossil Fuel and Cement CO₂ Emissions (FF_std)
@@ -467,6 +503,10 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-river
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Lateral River CO₂ Flux (River)
@@ -510,6 +550,10 @@ layers:
         - '#F18D6F'
         - '#D95847'
         - '#B40426'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-river-std
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Uncertainty - Lateral River CO₂ Flux (River_std)
@@ -552,7 +596,11 @@ layers:
         - '#DF2179'
         - '#C10E51'
         - '#92003F'
-        - '#67001F'        
+        - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean        
   - id: co2-emissions-wood
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Lateral Wood CO₂ Flux (Wood)
@@ -596,6 +644,10 @@ layers:
         - '#F18D6F'
         - '#D95847'
         - '#B40426'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: co2-emissions-wood-std
     stacCol: oco2-mip-co2budget-yeargrid-v1
     name: Uncertainty - Lateral Wood CO₂ Flux (Wood_std)
@@ -639,6 +691,10 @@ layers:
         - '#C10E51'
         - '#92003F'
         - '#67001F'
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block type='wide'>

--- a/datasets/population-density.mdx
+++ b/datasets/population-density.mdx
@@ -42,6 +42,10 @@ layers:
       - "#fc5b2e"
       - "#d41020"
       - "#800026"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block>

--- a/datasets/so2.mdx
+++ b/datasets/so2.mdx
@@ -47,6 +47,10 @@ layers:
       - "#fee090"
       - "#f46d43"
       - "#a50026"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 <Block type='full'>
   <Figure>

--- a/datasets/soilmoisture-volumetric.mdx
+++ b/datasets/soilmoisture-volumetric.mdx
@@ -47,6 +47,10 @@ layers:
         ::js ({ dateFns, datetime, compareDatetime }) => {
           if (dateFns && datetime && compareDatetime) return `${dateFns.format(datetime, 'MMM yyyy')} VS ${dateFns.format(compareDatetime, 'MMM yyyy')}`;
         }
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block>

--- a/datasets/stream-network.mdx
+++ b/datasets/stream-network.mdx
@@ -28,6 +28,10 @@ layers:
         - 1
         - 1
       nodata: 65535
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 
 ---
 

--- a/datasets/svi_overall.mdx
+++ b/datasets/svi_overall.mdx
@@ -56,6 +56,10 @@ layers:
       - "#2498c1"
       - "#234da0"
       - "#081d58"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
   - id: social-vulnerability-index-overall-nopop
     stacCol: social-vulnerability-index-overall-nopop
     name: Overall (NoPop) Social Vulnerability - Percentile Ranking
@@ -89,6 +93,10 @@ layers:
       - "#2498c1"
       - "#234da0"
       - "#081d58"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block>

--- a/datasets/tws-lis.mdx
+++ b/datasets/tws-lis.mdx
@@ -40,6 +40,10 @@ layers:
       - "#e0f3f8"
       - "#74add1"
       - "#313695"
+    analysis:
+      exclude: false
+      metrics:
+        - mean
 ---
 
 <Block>


### PR DESCRIPTION
When running zonal statistics analyses, the app by default shows all statistics on the same y-axis (mean, standard deviation, min, max, median). This is rarely useful and something we are going to address in the future.

e.g. consider the left vs the right view

![image](https://github.com/NASA-IMPACT/veda-config-eic/assets/3404817/266a269f-fa50-4eeb-ab28-9fbac6c8ab7e)

Until we implemented nicer charts, we can get better default views by setting the default metric to show to `mean` (continuous variables) or `median` (categorical).

That's done in this PR for all the EIC datasets.