### PR TITLE
Change footer link title to match nav

### DIFF
--- a/overrides/components/page-footer/component.tsx
+++ b/overrides/components/page-footer/component.tsx
@@ -263,7 +263,7 @@ export default function PageFooter(props) {
                 </li>
               )}
               <li>
-                <FooterMenuLink to="/visit">Visit the center</FooterMenuLink>
+                <FooterMenuLink to="/visit">Visit a center</FooterMenuLink>
               </li>
               <li>
                 <FooterMenuLink to="/teach">Teach</FooterMenuLink>


### PR DESCRIPTION
- [x] Changed footer link title "Visit the Center" -> "Visit a Center" to make it the same as the link in the top right nav