### PR TITLE
Content: Replace images with embedded youtube videos

### DIFF
--- a/stories/locfeature.IMMER.mdx
+++ b/stories/locfeature.IMMER.mdx
@@ -79,9 +79,10 @@ import { visitLocationFeaturesStoryIds } from '../overrides/common/story-data';
       Visualizations depict seasonal land surface changes, fostering a profound understanding of Earth's dynamic nature.
     </Prose> 
     <Figure>
-      <Image
-        src={new URL('./locfeature.IMMER/02-NASA_EIC_SpaceForEarth_TheBlueMarble.png', import.meta.url).href}
-        alt='rainbow colormap image of the hole in the ozone layer above the arctic.'
+      <Embed
+        height={400}
+        src="https://www.youtube.com/embed/lS5gE3mGLFE?autoplay=1&mute=1&controls=0&rel=0&playsinline=1&loop=1&playlist=lS5gE3mGLFE"
+        title="Scenes from Space for Earth: Blue Marble"
       />
     </Figure>
 </Block>
@@ -93,10 +94,10 @@ import { visitLocationFeaturesStoryIds } from '../overrides/common/story-data';
       Satellite motion paths are rendered with a 24-hour delay, providing a visually compelling exploration of their orbital activities.
     </Prose> 
     <Figure>
-      <Image
-        src={new URL('./locfeature.IMMER/03-NASA_EIC_SpaceForEarth_EyesOnTheEarth.png', import.meta.url).href}
-        alt='A woman stands alone in the inside of the Space for Earth exhibit with her arms outstretched.
-        Many white lines converge on her silhouette, which is projected onto the side walls.'
+      <Embed
+        height={400}
+        src="https://www.youtube.com/embed/KitqhmWsXvI?autoplay=1&mute=1&controls=0&rel=0&playsinline=1&loop=1&playlist=KitqhmWsXvI"
+        title="Scenes from Space for Earth: Eyes on the Earth"
       />
     </Figure>
 </Block>
@@ -108,9 +109,10 @@ import { visitLocationFeaturesStoryIds } from '../overrides/common/story-data';
       This includes seasonal polar ice changes and chlorophyll dynamics, offering insight into Earth's vital signs and the interconnected dance of life.
     </Prose> 
     <Figure>
-      <Image
-        src={new URL('./locfeature.IMMER/04-NASA_EIC_SpaceForEarth_EarthIsBreathing.png', import.meta.url).href}
-        alt='Photograph of the inside of the Space for Earth exhibit-- a cube painted pure black. The scene is illuminated by vivid green tree imagery on two side walls and floor. An image of earth as viewed from space is on the front wall.'
+      <Embed
+        height={400}
+        src="https://www.youtube.com/embed/_TVmm6g5KJM?autoplay=1&mute=1&controls=0&rel=0&playsinline=1&loop=1&playlist=_TVmm6g5KJM"
+        title="Scenes from Space for Earth: Earth is Breathing"
       />
     </Figure>
 </Block>
@@ -123,9 +125,10 @@ import { visitLocationFeaturesStoryIds } from '../overrides/common/story-data';
 
     </Prose> 
     <Figure>
-      <Image
-        src={new URL('./locfeature.IMMER/05-NASA_EIC_SpaceForEarth_EarthVitalSigns.png', import.meta.url).href}
-        alt='A group of men inside the Space for Earth exhibit. An image whirling sand and clouds is displayed on the front walls and stripes of color are smeared on the wall and side walls.'
+      <Embed
+        height={400}
+        src="https://www.youtube.com/embed/5X3w_GlxQ4U?autoplay=1&mute=1&controls=0&rel=0&playsinline=1&loop=1&playlist=5X3w_GlxQ4U"
+        title="Scenes from Space for Earth: Earth Vital Signs"
       />
     </Figure>
 </Block>
@@ -138,9 +141,10 @@ import { visitLocationFeaturesStoryIds } from '../overrides/common/story-data';
 
     </Prose> 
     <Figure>
-      <Image
-        src={new URL('./locfeature.IMMER/06-NASA_EIC_SpaceForEarth_AtmosphericRiver.png', import.meta.url).href}
-        alt='A group of visitors in the Space for Earth exhibit holding their arms above their heads. Their silhouettes are projected on the front wall and simulated rainfall is diverted by their presence.'
+      <Embed
+        height={400}
+        src="https://www.youtube.com/embed/0QA_TyydmTU?autoplay=1&mute=1&controls=0&rel=0&playsinline=1&loop=1&playlist=0QA_TyydmTU"
+        title="Scenes from Space for Earth: Atmospheric River"
       />
     </Figure>
 </Block>
@@ -153,9 +157,10 @@ import { visitLocationFeaturesStoryIds } from '../overrides/common/story-data';
 
     </Prose> 
     <Figure>
-      <Image
-        src={new URL('./locfeature.IMMER/07-NASA_EIC_SpaceForEarth_BlackMarble.png', import.meta.url).href}
-        alt='.'
+       <Embed
+        height={400}
+        src="https://www.youtube.com/embed/vE_k-ja01vo?autoplay=1&mute=1&controls=0&rel=0&playsinline=1&loop=1&playlist=vE_k-ja01vo"
+        title="Scenes from Space for Earth: Black marble"
       />
     </Figure>
 </Block>


### PR DESCRIPTION
## Adding content

Replace all of the static images with embedded youtube videos that loop. 

---

## Content checklist

Check the [Content Documentation](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/CONTENT.md) for more details.

### Any content
- [x] Cover image with proper attribution (when relevant) is present.
- [x] Cover images do not contain any text (they're used as a background and text may not be readable).
- [x] All images are not too big/heavy. As a general rule of thumb, they should not weigh more than 500KB, or be larger than 2000px. See the [media guide](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/frontmatter/media.md#media) for more info.
- [x] Content was added using the available [MDX Blocks](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/MDX_BLOCKS.md).

### Datasets
- [x] [Layer description](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/frontmatter/layer.md#properties) is defined.
- [x] [Layer legend](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/frontmatter/layer.md#legend) is setup.
- [x] The Dataset is showing up on the map correctly

### Stories
- [x] [Publication date](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/content/CONTENT.md#stories) value is set
