### PR TITLE
Update theme.AQ_.mdx to remove link to old ESRI site

### DIFF
--- a/stories/theme.AQ_.mdx
+++ b/stories/theme.AQ_.mdx
@@ -98,22 +98,6 @@ import contentArray from './theme.AQ_.introduction_air_quality/carousel_content.
 
 <Block>
   <Prose>
-    ## Explore the Air Quality Near You
-    <Link to="https://gis.earthdata.nasa.gov/portal/apps/sites/#/earth-information-center/pages/explore">
-      View the Interactive Maps
-    </Link>
-  </Prose>
-  <Figure>
-    <Image
-      src={new URL('./theme.AQ_.introduction_air_quality/air_quality_story_map.png', import.meta.url).href}
-      alt='world map of air quality in blue-yellow colormap'
-    />
-  </Figure>
-</Block>
-
-
-<Block>
-  <Prose>
     ## Trainings & Tools
     <Link to="https://appliedsciences.nasa.gov/what-we-do/capacity-building/arset/arset-air-quality-trainings">
       ARSET Air Quality Trainings (English)


### PR DESCRIPTION

![Screenshot 2024-01-22 at 3 33 30 PM](https://github.com/NASA-IMPACT/veda-config-eic/assets/7799423/27e4b3b9-2b78-4d9a-b344-306f410c4c7b)

We are moving to sunset the 

https://gis.earthdata.nasa.gov/portal/apps/sites/#/earth-information-center/

website. This block references content that we no longer want to point to (nor need to replicate).

## What am I changing and why

_Replace with brief description of the update and why it is needed. Link to relevant issues._

## How to test
_Replace with instructions on how this change be tested/verified._

## ⚠️ Checks

- [ ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config-ghg/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.