### PR TITLE
Add DAP tracking code

### DIFF
--- a/.env
+++ b/.env
@@ -20,3 +20,10 @@ MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 # PUBLIC_URL=http://example.com/mysite
 
 GOOGLE_FORM = 'https://docs.google.com/forms/d/1mDgFqUsNv90Js7pERNDbmyN5RksztIy5ZZojWD0n5Pg/viewform'
+
+# Add DAP script block with tracking code for the DAP compliance. 
+# Every public-facing NASA website must install the DAP tracking code on all public-facing pages.
+# This federal requirement was first published in OMB M-17-06 (issued in 2016) and was re-issued in OMB M-23-22 in September 2023. 
+
+CUSTOM_SCRIPT_SRC=https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=HQ
+CUSTOM_SCRIPT_ID=_fed_an_ua_tag


### PR DESCRIPTION
## What am I changing and why

Add DAP tracking code for federal websites.

## How to test
After deployed, inspect elements, find the dap tracking code there.

Depends on https://github.com/NASA-IMPACT/veda-config-eic/pull/93