### PR TITLE
change hyperweb embed url to explicitly include index.html

### DIFF
--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -35,6 +35,6 @@ import contentArray from './locfeature.HYPER/carousel_content.json';
         width:"100%",
         height:"calc(100vw * 9/32/0.8725)"
       }}
-        src="https://svs.gsfc.nasa.gov/webapps/hyperweb" />
+        src="https://svs.gsfc.nasa.gov/webapps/hyperweb/index.html" />
   </Figure>
 </Block>


### PR DESCRIPTION
## What am I changing and why

Changing url to explicitly include `index.html` so it embeds correctly, see current state of `staging.earth.gov/stories/hyperwall`:

<img width="1728" alt="image" src="https://github.com/NASA-IMPACT/veda-config-eic/assets/7799423/ad51244f-f200-447f-90da-d86fc2127cd2">

## How to test
Still working on getting approval for a deploy preview domain name so unfortunately testing has to be done on `staging.earth.gov` which means we need to merge to `develop` to see if it works. I'm really sorry folks... I promise we won't make a habit of this, I will try and get a deploy preview domain sorted so that we can test this on the auto-generated previews in the future but I don't think I can get it done on a turnaround time of ~1 day.

## ⚠️ Checks

- [ ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config-ghg/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.