### PR TITLE
fix height calculation (previously I had my browser set to 125% zoom, sorry :( )

### DIFF
--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -33,7 +33,7 @@ import contentArray from './locfeature.HYPER/carousel_content.json';
     <Embed
       style={{
         width:"100%",
-        height:"calc(100vw * 9/32/0.8725)"
+        height:"calc(95vw * 9/32)"
       }}
         src="https://svs.gsfc.nasa.gov/webapps/hyperweb/index.html" />
   </Figure>


### PR DESCRIPTION
i accidentally had my browser set to 125% zoom and so I didn't notice there was a ton of empty padding underneath the embedded hyperweb content.

<!-- -----------^ Click "Preview" for a functional view! -->

## Why are you creating this Pull Request?

- [Adding Datasets or Stories](?title=Content%3A%20%3Cname%3E&expand=1&template=content.md)
- [Version Release](?title=Deploy%20vX.X.X&expand=1&template=version_release.md)
- [Other](?expand=1&template=default.md)