### PR TITLE
HOTFIX: replace height calculation

### DIFF
--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -33,7 +33,8 @@ import contentArray from './locfeature.HYPER/carousel_content.json';
     <Embed
       style={{
         width:"100%",
-        height:"calc(85vw * 9/32)",
+        height:"calc(((100vw - 48px) * 0.28) + 64px)",
+        maxHeight:"calc(((1375px - 48px) * 0.28) + 80px)",
       }}
         src="https://svs.gsfc.nasa.gov/webapps/hyperweb/index.html" />
   </Figure>

--- a/stories/locfeature.HYPER.mdx
+++ b/stories/locfeature.HYPER.mdx
@@ -33,7 +33,7 @@ import contentArray from './locfeature.HYPER/carousel_content.json';
     <Embed
       style={{
         width:"100%",
-        height:"calc(95vw * 9/32)"
+        height:"calc(85vw * 9/32)",
       }}
         src="https://svs.gsfc.nasa.gov/webapps/hyperweb/index.html" />
   </Figure>


### PR DESCRIPTION


## What am I changing and why

this change shrinks the height of the hyperweb embed iframe to avoid extra whitespace. 
not sure why it appeared to work originally. perhaps some kind of cache issue.

before (live on Earth.gov): 
![image](https://github.com/NASA-IMPACT/veda-config-eic/assets/7799423/5635a8ec-de72-4428-ba31-d5b9e1852f24)
(ignore frames that are gray, they are CSP issues with Worldview and I've already sent them an email)

after: 
![image](https://github.com/NASA-IMPACT/veda-config-eic/assets/7799423/3c70c7d6-96a0-4c73-9442-6c77018cbe70)
(ignore frames that are gray, I didn't setup my reverse proxy so they are CSP issues with localhost)


## How to test
check that it looks right on staging.earth.gov but @slesaad  and I did that with the last one and I feel like I'm going crazy because it looked fine to me. That's why I suspect a cache issue.

@hanbyul-here  can you have a look at the height calculation and let me know if there's an intelligent way to do it that actually measures the height of the framed content rather than guessing? 

## ⚠️ Checks

- [ ] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config-ghg/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.