### PR TITLE
Fix US GHG Center shortform typo

### DIFF
--- a/overrides/components/visit-ghg.tsx
+++ b/overrides/components/visit-ghg.tsx
@@ -85,7 +85,7 @@ export default function VisitGHG({
                 radius="square"
                 variation="primary-fill"
               >
-                Visit the U.S. GHG Center website
+                Visit the US GHG Center website
               </Button>
             </div>
           </InfoImageContent>


### PR DESCRIPTION
## What am I changing and why

U.S. GHG Center -> US GHG Center (based on official GHG conventions)

## How to test
The blue button on the home page for visit GHG Center should say US GHG Center instead of U.S. GHG Center
