### PR TITLE
feat: migrate to production veda stac catalog and titiler AND update GHG URLs

### DIFF
--- a/.env
+++ b/.env
@@ -8,10 +8,10 @@ APP_DESCRIPTION='Explore our changing planet.'
 APP_CONTACT_EMAIL=eleanor.stokes@nasa.gov
 
 # Endpoint for the Tiler server. No trailing slash.
-API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
+API_RASTER_ENDPOINT='https://openveda.cloud/api/raster'
 
 # Endpoint for the STAC server. No trailing slash.
-API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
+API_STAC_ENDPOINT='https://openveda.cloud/api/stac'
 
 MAPBOX_STYLE_URL='mapbox://styles/covid-nasa/ckb01h6f10bn81iqg98ne0i2y'
 

--- a/datasets/epa-ch4emission-v2express.data.mdx
+++ b/datasets/epa-ch4emission-v2express.data.mdx
@@ -19,8 +19,8 @@ taxonomy:
       - Gridded Inventory
 layers:
   - id: total-methane
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Total Methane (annual)
     type: raster
@@ -83,8 +83,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: total-agriculture
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Total Agriculture (annual)
     type: raster
@@ -147,8 +147,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: enteric-fermentation
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Agriculture - Enteric Fermentation (annual)
     type: raster
@@ -211,8 +211,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: manure-management
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Agriculture - Manure Management (annual)
     type: raster
@@ -275,8 +275,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: rice-cultivation-l
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Agriculture - Rice Cultivation (annual)
     type: raster
@@ -339,8 +339,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: field-burning-l
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Agriculture - Field Burning (annual)
     type: raster
@@ -403,8 +403,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: total-natural-gas
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Total Natural Gas Systems (annual)
     type: raster
@@ -467,8 +467,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: exploration-ngs-l
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Natural Gas - Exploration (annual)
     type: raster
@@ -531,8 +531,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: production-ngs-l
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Natural Gas - Production (annual)
     type: raster
@@ -595,8 +595,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B2b-transmission-storage-ngs
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Natural Gas - Transmission and Storage (annual)
     type: raster
@@ -659,8 +659,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B2b-processing-ngs
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Natural Gas - Processing (annual)
     type: raster
@@ -723,8 +723,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B2b-distribution-ngs
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Natural Gas - Distribution (annual)
     type: raster
@@ -787,8 +787,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: post-meter-ng
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Natural Gas - Post-Meter (annual)
     type: raster
@@ -851,8 +851,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: total-petroleum
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Total Petroleum Systems (annual)
     type: raster
@@ -915,8 +915,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B2a-exploration-ps
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Petroleum - Exploration (annual)
     type: raster
@@ -979,8 +979,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B2a-production-ps
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Petroleum - Production (annual)
     type: raster
@@ -1043,8 +1043,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B2a-transport-ps
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Petroleum - Transportation (annual)
     type: raster
@@ -1107,8 +1107,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B2a-refining-ps
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Petroleum - Refining (annual)
     type: raster
@@ -1171,8 +1171,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: total-waste
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Total Waste (annual)
     type: raster
@@ -1235,8 +1235,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 5A1-msw-landfill-waste
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Waste - Municipal Solid Waste (MSW) Landfills (annual)
     type: raster
@@ -1299,8 +1299,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 5A1-industrial-landfill-waste
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Waste - Industrial Landfills (annual)
     type: raster
@@ -1363,8 +1363,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 5A1-dwtd-waste
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Waste - Domestic Wastewater Treatment & Discharge (annual)
     type: raster
@@ -1427,8 +1427,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 5A1-iwtd-waste
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Waste - Industrial Wastewater Treatment & Discharge (annual)
     type: raster
@@ -1491,8 +1491,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 5A1-composting-waste
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Waste - Composting (annual)
     type: raster
@@ -1555,8 +1555,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: total-coal-mines
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Total Coal Mines (annual)
     type: raster
@@ -1619,8 +1619,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B1a-underground-coal
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Coal Mining - Underground Mining (annual)
     type: raster
@@ -1683,8 +1683,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B1a-abn-underground-coal
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Coal Mining - Abandoned Underground Mines (annual)
     type: raster
@@ -1747,8 +1747,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1B1a-surface-coal
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Coal Mining - Surface Mining (annual)
     type: raster
@@ -1811,8 +1811,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: total-other
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Total Other (annual)
     type: raster
@@ -1875,8 +1875,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1A-stationary-combustion-other
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Other - Stationary combustion (annual)
     type: raster
@@ -1939,8 +1939,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1A-mobile-combustion-other
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Other - Mobile combustion (annual)
     type: raster
@@ -2003,8 +2003,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1A-abn-ong-other
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Other - Abandoned Oil and Gas Wells (annual)
     type: raster
@@ -2067,8 +2067,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1A-petro-production-other
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Other - Petrochemical Production (annual)
     type: raster
@@ -2131,8 +2131,8 @@ layers:
         - "#721E17"
         - "#521A13"
   - id: 1A-ferroalloy-production-other
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: epa-ch4emission-yeargrid-v2express
     name: Other - Ferroalloy Production (annual)
     type: raster


### PR DESCRIPTION
<!-- -----------^ Click "Preview" for a functional view! -->
Linked PR: https://github.com/NASA-IMPACT/veda-ui/issues/1019

## Changed
- Base STAC API and Raster API urls updated for production openveda.cloud
- GHG center STAC and Raster API urls updated to align with recent GHG path changes unrelated to openveda.cloud

## Why are you creating this Pull Request?

To migrate the Dashboard usage of VEDA backend APIs to new production openveda.cloud VEDA instance.

## How tested
Steps taken to validate the new production VEDA instance are documented [here](https://github.com/NASA-IMPACT/veda-architecture/issues/441).