### PR TITLE
move mobile climate mapper to the features section

### DIFF
--- a/overrides/common/story-data.ts
+++ b/overrides/common/story-data.ts
@@ -32,6 +32,7 @@ export const visitLocationFeaturesStoryIds = {
     "eyes_on_earth",
     "hometown_dashboard",
     "time_unveiled",
+    "mobile_climate_mapper"
   ]
 };
 

--- a/stories/locfeature.HOMETOWN.mdx
+++ b/stories/locfeature.HOMETOWN.mdx
@@ -30,5 +30,3 @@ import contentArray from './locfeature.HOMETOWN/carousel_content.jsx';
     <Carousel items={contentArray} />
   </Figure>
 </Block>
-
-<CardGallery title={"Related Applications"} storyIds={['mobile_climate_mapper']} />


### PR DESCRIPTION
move feature card out of related applications of hometown dashboard and into the feature card section. 