### PR TITLE
Bump ui version to v5.9.0 and pass new prop to the override component

### DIFF
--- a/overrides/components/related-content-cards.tsx
+++ b/overrides/components/related-content-cards.tsx
@@ -33,7 +33,7 @@ export default function EICRelatedContents({ storyIds }:ContentsPropType) {
 
   const cards = relatedData.map((t) => (
     <li key={`${t.id}-card`}>
-      <StyledCard 
+      <StyledCard
         key={t.id}
         linkLabel="View more"
         linkTo={t.asLink?.url?? `/stories/${t.id}`}
@@ -41,6 +41,7 @@ export default function EICRelatedContents({ storyIds }:ContentsPropType) {
         description={t.description}
         imgSrc={t.media.src}
         imgAlt={t.media.alt}
+        hideExternalLinkBadge={t.hideExternalLinkBadge}
       />
     </li>
   ))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-config",
   "description": "Configuration for Veda",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "source": "./.veda/ui/app/index.html",
   "license": "Apache-2.0",
   "scripts": {

--- a/stories/locfeature.MCM.mdx
+++ b/stories/locfeature.MCM.mdx
@@ -9,6 +9,7 @@ description: "
 "
 asLink:
   url: https://earth.gov/mobile-climate-mapper/
+hideExternalLinkBadge: true
 media:
   src: ::file ./external_headers/mcm.png
   alt: "


### PR DESCRIPTION
1. Bump the UI version to v5.9.0
2. Pass in the new `hideExternalLinkBadge` prop to the related content override
3. Use the new `hideExternalLinkBadge` for the Mobile Climate Mapper card to hide the "External Link" badge for the card (the MCM card is shown under the `Visit a Center` link in the footer)


