### PR TITLE
add new narrated video to slr theme page

### DIFF
--- a/stories/theme.SLR.mdx
+++ b/stories/theme.SLR.mdx
@@ -78,10 +78,10 @@ import { GridContainer, Grid } from '$veda-ui/@trussworks/react-uswds';
     <Embed
       height="405"
       src="https://www.youtube.com/embed/T7qcwWVMiVs"
-      title="NASA and Sea Level Rise"
+      title="NASA and Sea Level Change"
     />
     <Caption attrAuthor="NASA" attrUrl="https://nasa.gov/">
-    The city of Mobile, AL is working with NASA's Sea Level Rise Team to plan for future infrastructure projects and to protect Mobile's coastal resources. As sea levels rise globally, coastal cities feel the effects of more frequent and more severe storms and flooding. NASA's sea level rise data, in conjunction with NOAA data, helps Mobile and other coastal communities plan for a more resilient future.
+    The city of Mobile, AL is working with NASA's Sea Level Change Team to plan for future infrastructure projects and to protect Mobile's coastal resources. When sea levels rise, coastal cities feel the effects of more frequent and more severe storms and flooding. NASA's sea level change data, in conjunction with NOAA data, helps Mobile and other coastal communities plan for a more resilient future.
     </Caption>
   </Figure>
 </Block>

--- a/stories/theme.SLR.mdx
+++ b/stories/theme.SLR.mdx
@@ -73,6 +73,19 @@ import { GridContainer, Grid } from '$veda-ui/@trussworks/react-uswds';
     </Figure>
 </Block>
 
+<Block type="wide">
+  <Figure>
+    <Embed
+      height="405"
+      src="https://www.youtube.com/embed/T7qcwWVMiVs"
+      title="NASA and Sea Level Rise"
+    />
+    <Caption attrAuthor="NASA" attrUrl="https://nasa.gov/">
+    The city of Mobile, AL is working with NASA's Sea Level Rise Team to plan for future infrastructure projects and to protect Mobile's coastal resources. As sea levels rise globally, coastal cities feel the effects of more frequent and more severe storms and flooding. NASA's sea level rise data, in conjunction with NOAA data, helps Mobile and other coastal communities plan for a more resilient future.
+    </Caption>
+  </Figure>
+</Block>
+
 <Block type='wide'>
   <Figure>
     <Carousel items={contentArray} />


### PR DESCRIPTION
## What am I changing and why

EIC video producers created a new narrated video that needs to be added to the SLR theme page in line with the other narrated videos. 

## How to test
Visit the page and see if the Youtube video is embedded correctly. 

## ⚠️ Checks

- [x] I have confirmed that [updating the `veda-ui` submodule](https://github.com/NASA-IMPACT/veda-config-ghg/blob/main/docs/DEVELOPMENT.md#development) is needed and **only done so** if that's the case.